### PR TITLE
feat: add locExcludedExtensions and keep binaryExtensions binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,10 @@ This extension uses [scc](https://github.com/boyter/scc) for accurate lines-of-c
 | `repoStats.defaultColorMode`     | `"language"` | Default treemap color mode (`language` or `age`)    |
 | `repoStats.showEmptyTimePeriods` | `true`       | Show weeks/months with no activity in charts        |
 | `repoStats.generatedPatterns`    | See below    | Glob patterns to identify generated files           |
-| `repoStats.binaryExtensions`     | See below    | File extensions considered as binary                |
+| `repoStats.binaryExtensions`     | See below    | File extensions considered binary for classification and binary-focused views |
+| `repoStats.locExcludedExtensions`| `[]`         | File extensions excluded from LOC counting          |
+
+Tip: If assets like `.svg` files inflate LOC totals for your project, add `.svg` to `repoStats.locExcludedExtensions`.
 
 <details>
 <summary>Default Generated Patterns</summary>

--- a/package.json
+++ b/package.json
@@ -117,7 +117,12 @@
             ".sqlite", ".db", ".mdb",
             ".vhdx", ".vmdk", ".iso", ".dmg", ".deb", ".rpm", ".icns"
           ],
-          "description": "File extensions considered as binary files (images, fonts, compiled, etc.). These have 0 LOC but are shown in treemap Size mode."
+          "description": "File extensions considered binary for classification and binary-focused views."
+        },
+        "repoStats.locExcludedExtensions": {
+          "type": "array",
+          "default": [],
+          "description": "File extensions to exclude from LOC counting (e.g. .svg). Accepts forms like .svg, svg, or **/*.svg."
         },
         "repoStats.showEmptyTimePeriods": {
           "type": "boolean",

--- a/src/analyzers/locCounter.test.ts
+++ b/src/analyzers/locCounter.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for LOC extension filtering helpers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeExtensionForFilter,
+  shouldExcludeFileByExtension,
+} from './locCounter';
+
+describe('normalizeExtensionForFilter', () => {
+  it('normalizes extension values to lowercase dot-prefixed format', () => {
+    expect(normalizeExtensionForFilter('.svg')).toBe('.svg');
+    expect(normalizeExtensionForFilter('svg')).toBe('.svg');
+    expect(normalizeExtensionForFilter('  .SVG  ')).toBe('.svg');
+    expect(normalizeExtensionForFilter('TSX')).toBe('.tsx');
+  });
+
+  it('accepts common glob-like forms used by users', () => {
+    expect(normalizeExtensionForFilter('*.svg')).toBe('.svg');
+    expect(normalizeExtensionForFilter('**/*.svg')).toBe('.svg');
+    expect(normalizeExtensionForFilter('assets/*.svg')).toBe('.svg');
+  });
+
+  it('returns null for invalid extension values', () => {
+    expect(normalizeExtensionForFilter('')).toBeNull();
+    expect(normalizeExtensionForFilter('   ')).toBeNull();
+    expect(normalizeExtensionForFilter('.')).toBeNull();
+    expect(normalizeExtensionForFilter('folder/svg')).toBeNull();
+    expect(normalizeExtensionForFilter('assets/icons')).toBeNull();
+    expect(normalizeExtensionForFilter('*')).toBeNull();
+  });
+});
+
+describe('shouldExcludeFileByExtension', () => {
+  it('matches excluded extensions case-insensitively', () => {
+    const excluded = new Set(['.svg', '.png']);
+
+    expect(shouldExcludeFileByExtension('icons/logo.svg', excluded)).toBe(true);
+    expect(shouldExcludeFileByExtension('icons/LOGO.SVG', excluded)).toBe(true);
+    expect(shouldExcludeFileByExtension('icons\\logo.SVG', excluded)).toBe(true);
+    expect(shouldExcludeFileByExtension('icons/logo.jpg', excluded)).toBe(false);
+  });
+
+  it('supports dotfile names when configured explicitly', () => {
+    const excluded = new Set(['.env']);
+
+    expect(shouldExcludeFileByExtension('.env', excluded)).toBe(true);
+    expect(shouldExcludeFileByExtension('config/.ENV', excluded)).toBe(true);
+    expect(shouldExcludeFileByExtension('config/.env.local', excluded)).toBe(false);
+  });
+
+  it('returns false when exclusion set is empty', () => {
+    expect(shouldExcludeFileByExtension('icons/logo.svg', new Set())).toBe(false);
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -166,6 +166,7 @@ export interface ExtensionSettings {
   defaultColorMode: 'language' | 'age' | 'complexity' | 'density';
   generatedPatterns: string[];
   binaryExtensions: string[];
+  locExcludedExtensions: string[];
   showEmptyTimePeriods: boolean;
   defaultGranularityMode: 'auto' | 'weekly' | 'monthly';
   autoGranularityThreshold: number; // Weeks threshold for auto mode (default 20)

--- a/src/webview/provider.ts
+++ b/src/webview/provider.ts
@@ -210,6 +210,9 @@ export class RepoStatsProvider implements vscode.WebviewViewProvider {
     if (settings.binaryExtensions !== undefined) {
       await config.update('binaryExtensions', settings.binaryExtensions, vscode.ConfigurationTarget.Global);
     }
+    if (settings.locExcludedExtensions !== undefined) {
+      await config.update('locExcludedExtensions', settings.locExcludedExtensions, vscode.ConfigurationTarget.Global);
+    }
     if (settings.showEmptyTimePeriods !== undefined) {
       await config.update('showEmptyTimePeriods', settings.showEmptyTimePeriods, vscode.ConfigurationTarget.Global);
     }
@@ -339,6 +342,7 @@ export class RepoStatsProvider implements vscode.WebviewViewProvider {
         '.sqlite', '.db', '.mdb',
         '.vhdx', '.vmdk', '.iso', '.dmg', '.deb', '.rpm', '.icns',
       ]),
+      locExcludedExtensions: config.get<string[]>('locExcludedExtensions', []),
       showEmptyTimePeriods: config.get<boolean>('showEmptyTimePeriods', true),
       defaultGranularityMode: config.get<'auto' | 'weekly' | 'monthly'>('defaultGranularityMode', 'auto'),
       autoGranularityThreshold: config.get<number>('autoGranularityThreshold', 20),

--- a/webview-ui/src/components/settings/GeneralSettings.tsx
+++ b/webview-ui/src/components/settings/GeneralSettings.tsx
@@ -60,10 +60,18 @@ export function GeneralSettings({ settings, data, updateSettings, requestRefresh
 
         <PatternListSetting
           title="Binary File Extensions"
-          description="File extensions considered binary (images, fonts, compiled, etc.). These have 0 LOC but appear in Size mode."
+          description="File extensions considered binary for classification and binary-focused views."
           patterns={settings.binaryExtensions || []}
           onChange={(patterns) => updateSettings({ binaryExtensions: patterns })}
           placeholder="e.g., .png, .woff2"
+        />
+
+        <PatternListSetting
+          title="LOC Excluded Extensions"
+          description="File extensions excluded from LOC counting (use this for files like .svg that should not inflate code totals)."
+          patterns={settings.locExcludedExtensions || []}
+          onChange={(patterns) => updateSettings({ locExcludedExtensions: patterns })}
+          placeholder="e.g., .svg, svg, **/*.svg"
         />
 
         <NumberSetting
@@ -82,7 +90,7 @@ export function GeneralSettings({ settings, data, updateSettings, requestRefresh
           Re-analyze Repository
         </button>
         <p className="settings-hint">
-          Click to re-analyze after changing exclude or generated patterns.
+          Click to re-analyze after changing exclude, generated, binary, or LOC-excluded extension patterns.
         </p>
       </div>
     </>

--- a/webview-ui/src/types.ts
+++ b/webview-ui/src/types.ts
@@ -112,6 +112,7 @@ export interface ExtensionSettings {
   defaultColorMode: 'language' | 'age' | 'complexity' | 'density';
   generatedPatterns: string[];
   binaryExtensions: string[];
+  locExcludedExtensions: string[];
   showEmptyTimePeriods: boolean;
   defaultGranularityMode: 'auto' | 'weekly' | 'monthly';
   autoGranularityThreshold: number; // Weeks threshold for auto mode (default 20)

--- a/webview-ui/src/utils/fileTypes.test.ts
+++ b/webview-ui/src/utils/fileTypes.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { isBinaryFile, isCodeLanguage, BINARY_EXTENSIONS, CODE_LANGUAGES } from './fileTypes';
+import {
+  isBinaryFile,
+  isCodeLanguage,
+  BINARY_EXTENSIONS,
+  CODE_LANGUAGES,
+  buildBinaryExtensionSet,
+  normalizeExtension,
+} from './fileTypes';
 
 describe('fileTypes', () => {
   describe('isBinaryFile', () => {
@@ -67,6 +74,26 @@ describe('fileTypes', () => {
     it('should handle paths with directories', () => {
       expect(isBinaryFile('assets/images/logo.png')).toBe(true);
       expect(isBinaryFile('src/components/App.tsx')).toBe(false);
+    });
+
+    it('should support custom binary extension sets', () => {
+      const customBinary = buildBinaryExtensionSet(['.svg']);
+      expect(isBinaryFile('icon.svg', customBinary)).toBe(true);
+      expect(isBinaryFile('app.ts', customBinary)).toBe(false);
+    });
+  });
+
+  describe('binary extension normalization', () => {
+    it('should normalize common extension forms', () => {
+      expect(normalizeExtension('.SVG')).toBe('.svg');
+      expect(normalizeExtension('svg')).toBe('.svg');
+      expect(normalizeExtension('**/*.svg')).toBe('.svg');
+    });
+
+    it('should reject invalid extension forms', () => {
+      expect(normalizeExtension('')).toBeNull();
+      expect(normalizeExtension('*')).toBeNull();
+      expect(normalizeExtension('assets/icons')).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Context

This PR addresses extension-based LOC exclusion while keeping binary classification semantics clean and explicit.

## User prompt #1

> I want the ability to ignore certain file types/extensions, and those not be included in the LOC counts. My specific example was .svg files because my repo has a bunch and they inflate the LOC count in a way that is not really true to my project scope. Do a thorough check for what would be required to implement this cleanly and comprehensively. If there are open questions/edge cases that need to be handled due to this let me know and lets workshop those together

## User prompt #2

> what if i want to ignore any other type of file. Say for example i want all .ts files ignored? 
> 1. Will it be ignored if i add it to the list of binary file extensions?
> 2. if yes, then is that the behaviour we want? Since the word binary is somehow not quite the correct one in that case right? 
>
> What do you think? Is this functionality that we should have at all? or to what extent is this already an existing feature that i just missed? Is the current PR adding only .svg functionality? or is it general?

## Summary of assistant response to prompt #2

- Yes, extension-based filtering should be **general**, not `.svg`-only.
- Using `binaryExtensions` for LOC exclusion is confusing semantically.
- Better design: keep `binaryExtensions` truly binary-focused, and add a dedicated setting for LOC exclusion.
- This PR implements exactly that split.

## What changed

### 1) New dedicated setting for LOC exclusion
- Added `repoStats.locExcludedExtensions` (default: `[]`)
- Purpose: extensions excluded from LOC counting
- Accepts forms like:
  - `.svg`
  - `svg`
  - `**/*.svg`

### 2) Kept `binaryExtensions` binary-focused
- `repoStats.binaryExtensions` remains for binary classification / binary-focused UI behavior
- It no longer serves as the generic LOC exclusion mechanism

### 3) LOC pipeline wiring
- `src/analyzers/locCounter.ts`
  - `countLines(excludePatterns, locExcludedExtensions?)`
  - normalize + match extension entries
  - filter matching files out of scc LOC results
- `src/analyzers/coordinator.ts`
  - passes `locExcludedExtensions` into LOC counting
  - ensures files excluded only via LOC setting are not reintroduced as “binary”
  - allows files to still appear as binary when explicitly configured as binary

### 4) Settings plumbing
- Added `locExcludedExtensions` to shared extension/webview settings types:
  - `src/types/index.ts`
  - `webview-ui/src/types.ts`
- Added read/write support in provider:
  - `src/webview/provider.ts`
- Added contribution schema:
  - `package.json`

### 5) UI + docs updates
- Settings UI now has a separate section:
  - **LOC Excluded Extensions** (`webview-ui/src/components/settings/GeneralSettings.tsx`)
- Updated `README.md` settings table and added `.svg` usage tip

### 6) Tests
- Added analyzer tests:
  - `src/analyzers/locCounter.test.ts`
- Extended file type utility tests:
  - `webview-ui/src/utils/fileTypes.test.ts`

## Resulting behavior

- Add `.ts` to `binaryExtensions` only → **does not** exclude TypeScript LOC.
- Add `.ts` to `locExcludedExtensions` → TypeScript LOC is excluded.
- Add `.svg` to `locExcludedExtensions` → `.svg` files no longer inflate LOC.

## Validation

- ✅ `npm run typecheck`
- ✅ `npm run compile`
- ✅ targeted tests:
  - `src/analyzers/locCounter.test.ts`
  - `webview-ui/src/utils/fileTypes.test.ts`

- ⚠️ `npm run validate` currently fails due a pre-existing ESLint repo-wide tooling issue:
  - `Definition for rule '@typescript-eslint/semi' was not found`
  - unrelated to this feature's changes
